### PR TITLE
feat: Add Shiki diff highlighting support

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,8 +4,34 @@ const { initOpenNextCloudflareForDev } = require('@opennextjs/cloudflare');
 
 const withNextra = require('nextra')({
 	theme: 'nextra-theme-blog',
-	themeConfig: './theme.config.js'
-	// optional: add `unstable_staticImage: true` to enable Nextra's auto image import
+	themeConfig: './theme.config.js',
+	mdxOptions: {
+		rehypePrettyCodeOptions: {
+			transformers: [
+				// Import transformers dynamically at build time
+				// These enable [!code ++], [!code --], [!code highlight], [!code focus] notation
+				...(function() {
+					try {
+						const { 
+							transformerNotationDiff,
+							transformerNotationHighlight,
+							transformerNotationFocus,
+							transformerNotationErrorLevel
+						} = require('@shikijs/transformers');
+						return [
+							transformerNotationDiff(),
+							transformerNotationHighlight(),
+							transformerNotationFocus(),
+							transformerNotationErrorLevel()
+						];
+					} catch (e) {
+						console.warn('Shiki transformers not installed, skipping...');
+						return [];
+					}
+				})()
+			]
+		}
+	}
 });
 
 // Set `NEXT_OUTPUT=export` to build a fully-static export (no Workers runtime, no cold starts).

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "upload": "node ./scripts/handleUnpublishedPosts.js hide && opennextjs-cloudflare build && opennextjs-cloudflare upload; node ./scripts/handleUnpublishedPosts.js restore"
   },
   "dependencies": {
+    "@shikijs/transformers": "^1.29.2",
     "clsx": "^2.1.1",
     "glob": "^10.3.10",
     "gray-matter": "^4.0.3",

--- a/styles/main.css
+++ b/styles/main.css
@@ -63,3 +63,130 @@ img.next-image {
 .nav-line .nav-link {
   color: #69778c;
 }
+
+/* ==========================================================
+   Shiki Transformers - Diff, Highlight, Focus, Error Styling
+   ========================================================== */
+
+/* Diff notation: [!code ++] and [!code --] */
+pre.shiki .line.diff {
+  display: inline-block;
+  width: calc(100% + 2rem);
+  margin: 0 -1rem;
+  padding: 0 1rem;
+}
+
+pre.shiki .line.diff.add {
+  background-color: rgba(46, 160, 67, 0.15);
+}
+
+pre.shiki .line.diff.remove {
+  background-color: rgba(248, 81, 73, 0.15);
+  opacity: 0.7;
+}
+
+pre.shiki .line.diff.add::before {
+  content: '+';
+  position: absolute;
+  left: 0.5rem;
+  color: #3fb950;
+}
+
+pre.shiki .line.diff.remove::before {
+  content: '-';
+  position: absolute;
+  left: 0.5rem;
+  color: #f85149;
+}
+
+pre.shiki.has-diff {
+  padding-left: 2rem;
+}
+
+pre.shiki.has-diff .line {
+  position: relative;
+}
+
+/* Highlight notation: [!code highlight] */
+pre.shiki .line.highlighted {
+  display: inline-block;
+  width: calc(100% + 2rem);
+  margin: 0 -1rem;
+  padding: 0 1rem;
+  background-color: rgba(101, 117, 133, 0.16);
+}
+
+pre.shiki.has-highlighted {
+  padding-left: 2rem;
+}
+
+/* Word highlight */
+pre.shiki .highlighted-word {
+  background-color: rgba(101, 117, 133, 0.4);
+  border: 1px solid rgba(101, 117, 133, 0.6);
+  padding: 1px 3px;
+  margin: -1px -3px;
+  border-radius: 4px;
+}
+
+/* Focus notation: [!code focus] */
+pre.shiki:has(.line.focused) .line:not(.focused) {
+  filter: blur(0.095rem);
+  opacity: 0.5;
+  transition: filter 0.35s, opacity 0.35s;
+}
+
+pre.shiki:has(.line.focused):hover .line:not(.focused) {
+  filter: blur(0);
+  opacity: 1;
+}
+
+pre.shiki .line.focused {
+  display: inline-block;
+  width: calc(100% + 2rem);
+  margin: 0 -1rem;
+  padding: 0 1rem;
+  background-color: rgba(101, 117, 133, 0.1);
+}
+
+/* Error level notation: [!code error], [!code warning], [!code info] */
+pre.shiki .line.highlighted.error {
+  background-color: rgba(244, 63, 94, 0.15);
+}
+
+pre.shiki .line.highlighted.warning {
+  background-color: rgba(234, 179, 8, 0.15);
+}
+
+pre.shiki .line.highlighted.info {
+  background-color: rgba(59, 130, 246, 0.15);
+}
+
+/* Dark mode adjustments */
+html.dark pre.shiki .line.diff.add {
+  background-color: rgba(46, 160, 67, 0.2);
+}
+
+html.dark pre.shiki .line.diff.remove {
+  background-color: rgba(248, 81, 73, 0.2);
+}
+
+html.dark pre.shiki .line.highlighted {
+  background-color: rgba(101, 117, 133, 0.25);
+}
+
+html.dark pre.shiki .highlighted-word {
+  background-color: rgba(101, 117, 133, 0.5);
+}
+
+html.dark pre.shiki .line.highlighted.error {
+  background-color: rgba(244, 63, 94, 0.2);
+}
+
+html.dark pre.shiki .line.highlighted.warning {
+  background-color: rgba(234, 179, 8, 0.2);
+}
+
+html.dark pre.shiki .line.highlighted.info {
+  background-color: rgba(59, 130, 246, 0.2);
+}


### PR DESCRIPTION
## ✨ Shiki Code Block Notation Support

Adds @shikijs/transformers for enhanced code block notation in blog posts.

### Features Added

| Notation | Effect | Example |
|----------|--------|---------|
| `[!code ++]` | Green diff addition | Shows line in green with + prefix |
| `[!code --]` | Red diff deletion | Shows line in red with - prefix |
| `[!code highlight]` | Line highlighting | Highlights the line |
| `[!code focus]` | Focus mode | Dims all other lines |
| `[!code error]` | Error notation | Shows error styling |
| `[!code warning]` | Warning notation | Shows warning styling |

### Usage in MDX

```js
const oldValue = 'remove me'; // [!code --]
const newValue = 'add me';    // [!code ++]
```

### Technical Changes

- **next.config.js**: Added transformers to rehypePrettyCodeOptions
- **package.json**: Added @shikijs/transformers dependency
- **styles/main.css**: 127 lines of CSS for all notation styles with dark mode

### Tested

- All diff notation styles render correctly
- Dark mode compatible
- No build warnings

---

Closes #1

This patch was created Feb 27 but couldn't be pushed until now (PAT was broken for 8 days).